### PR TITLE
amd64ではi386用のlibssl-devはインストール出来ないのでいったん諦める

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ ENV APP_PATH /opt/apps
 ENV HOME /home/app
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && apt-get install -y --no-install-recommends cmake build-essential gdb nano strace
-RUN if [ "${TARGETARCH}" = "amd64" ]; then apt-get install -y --no-install-recommends libc6-dev-i386 gcc-multilib libssl-dev && rustup target add i686-unknown-linux-gnu; fi
+RUN apt-get update && apt-get install -y --no-install-recommends cmake build-essential gdb nano strace libssl-dev
+RUN if [ "${TARGETARCH}" = "amd64" ]; then apt-get install -y --no-install-recommends libc6-dev-i386 gcc-multilib && rustup target add i686-unknown-linux-gnu; fi
 RUN groupadd -r app && useradd -r -g app app
 RUN mkdir ${HOME}
 COPY . ${APP_PATH}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- アーキテクチャに基づいた条件付きインストールの改善と、`libssl-dev` パッケージの追加を含む Dockerfile の変更。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->